### PR TITLE
Added Terminal Services and Graphics state telemetry trackers

### DIFF
--- a/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
@@ -1,0 +1,129 @@
+﻿#if NETCOREAPP3_0 || NET461 || NETFX_CORE
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.ApplicationInsights.WindowsDesktop
+{
+    /// <summary>
+    /// A telemetry context initializer that will gather graphics capabilities information.
+    /// </summary> 
+    public class GraphicsTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly double _featurelevel = 0;
+#if !NETFX_CORE
+        private readonly bool _softwareRenderingRegistry;
+        private readonly string[] _drivers;
+#endif
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphicsTelemetryInitializer"/> class.
+        /// </summary>
+        public GraphicsTelemetryInitializer()
+        {
+            try { _featurelevel = GetFeatureLevel(); }
+            catch { }
+#if !NETFX_CORE
+            try { _drivers = GetDrivers().ToArray(); }
+            catch { _drivers = new string[] { }; }
+            var disable = Win32.Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Avalon.Graphics", "DisableHWAcceleration", 0);
+            _softwareRenderingRegistry = (disable is int value && value == 1);
+            System.Windows.Media.RenderCapability.TierChanged += RenderCapability_TierChanged;
+#endif
+        }
+
+#if !NETFX_CORE
+        private void RenderCapability_TierChanged(object sender, EventArgs e)
+        {
+            //TODO
+            //DiagnosticsClient.TrackEvent("WPF Rendering Capability Tier Changed", new Dictionary<string, string> { { "DX Rendering Capability Tier", System.Windows.Media.RenderCapability.Tier.ToString() } });
+        }
+#endif
+        /// <summary>
+        /// Populates graphics properties on a telemetry item.
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (_featurelevel > 0)
+                telemetry.Context.GlobalProperties["DX FeatureLevel"] = (_featurelevel).ToString();
+#if !NETFX_CORE
+            telemetry.Context.GlobalProperties["DX Max Hardware Texture Size"] = System.Windows.Media.RenderCapability.MaxHardwareTextureSize.ToString();
+            telemetry.Context.GlobalProperties["WPF Registry Forced Software Rendering"] = _softwareRenderingRegistry.ToString();
+            telemetry.Context.GlobalProperties["WPF Process RenderMode"] = System.Windows.Media.RenderOptions.ProcessRenderMode.ToString();
+            telemetry.Context.GlobalProperties["WPF Rendering Capability Tier"] = System.Windows.Media.RenderCapability.Tier.ToString();
+            for (int i = 0; i < _drivers.Length; i++)
+            {
+                telemetry.Context.GlobalProperties[$"Graphics Driver {i+1}"] = _drivers[i];
+            }
+#endif
+        }
+
+#if !NETFX_CORE
+        private static IEnumerable<string> GetDrivers()
+        {
+            using (var objSearcher = new System.Management.ManagementObjectSearcher("Select * from Win32_VideoController"))
+            {
+                using (var objCollection = objSearcher.Get())
+                {
+                    foreach (var obj in objCollection)
+                    {
+                        yield return $"{obj.Properties["Name"].Value}, Version={obj.Properties["DriverVersion"].Value}";
+                    }
+                }
+            }
+        }
+#endif
+
+        private static double GetFeatureLevel()
+        {
+            IntPtr deviceOut;
+            IntPtr immediateContextOut;
+            uint featureLevelRef;
+            uint[] levels = {
+                    D3D_FEATURE_LEVEL_12_1, D3D_FEATURE_LEVEL_12_0,
+                    D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
+                    D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0,
+                    D3D_FEATURE_LEVEL_9_3, D3D_FEATURE_LEVEL_9_2, D3D_FEATURE_LEVEL_9_1
+                };
+            D3D11CreateDevice(
+                IntPtr.Zero,
+                1, //Hardware
+                IntPtr.Zero, // software renderer module 
+                0, //Creation flags
+                levels,
+                (uint)levels.Length,
+                7, //DX11
+                out deviceOut,
+                out featureLevelRef,
+                out immediateContextOut);
+            if (deviceOut != null) Marshal.Release(deviceOut);
+            if (immediateContextOut != null) Marshal.Release(immediateContextOut);
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_9_1) return 9.1;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_9_2) return 9.2;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_9_3) return 9.3;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_10_0) return 10.0;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_10_1) return 10.1;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_11_0) return 11.0;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_11_1) return 11.1;
+            if (featureLevelRef <= D3D_FEATURE_LEVEL_12_0) return 12.0;
+            return 12.1;
+        }
+
+        [DllImport("d3d11.dll", CallingConvention = CallingConvention.StdCall)]
+        private static extern int D3D11CreateDevice(IntPtr pAdapter, int driverType, IntPtr software, uint flags, uint[] pFeatureLevels, uint featureLevels, uint sdkVersion, [Out] out IntPtr ppDevice, [Out]out uint pFeatureLevel, [Out] out IntPtr ppImmediateContext);
+
+        private const uint D3D_FEATURE_LEVEL_9_1 = 0x9100;
+        private const uint D3D_FEATURE_LEVEL_9_2 = 0x9200;
+        private const uint D3D_FEATURE_LEVEL_9_3 = 0x9300;
+        private const uint D3D_FEATURE_LEVEL_10_0 = 0xa000;
+        private const uint D3D_FEATURE_LEVEL_10_1 = 0xa100;
+        private const uint D3D_FEATURE_LEVEL_11_0 = 0xb000;
+        private const uint D3D_FEATURE_LEVEL_11_1 = 0xb100;
+        private const uint D3D_FEATURE_LEVEL_12_0 = 0xc000;
+        private const uint D3D_FEATURE_LEVEL_12_1 = 0xc100;
+        private const uint D3D_DRIVER_TYPE_NULL = 3;
+    }
+}
+#endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
@@ -30,17 +30,9 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
             catch { _drivers = new string[] { }; }
             var disable = Win32.Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Avalon.Graphics", "DisableHWAcceleration", 0);
             _softwareRenderingRegistry = (disable is int value && value == 1);
-            System.Windows.Media.RenderCapability.TierChanged += RenderCapability_TierChanged;
 #endif
         }
 
-#if !NETFX_CORE
-        private void RenderCapability_TierChanged(object sender, EventArgs e)
-        {
-            //TODO
-            //DiagnosticsClient.TrackEvent("WPF Rendering Capability Tier Changed", new Dictionary<string, string> { { "DX Rendering Capability Tier", System.Windows.Media.RenderCapability.Tier.ToString() } });
-        }
-#endif
         /// <summary>
         /// Populates graphics properties on a telemetry item.
         /// </summary>
@@ -59,6 +51,8 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
             }
 #endif
         }
+
+
 
 #if !NETFX_CORE
         private static IEnumerable<string> GetDrivers()
@@ -123,7 +117,7 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
         private const uint D3D_FEATURE_LEVEL_11_1 = 0xb100;
         private const uint D3D_FEATURE_LEVEL_12_0 = 0xc000;
         private const uint D3D_FEATURE_LEVEL_12_1 = 0xc100;
-        private const uint D3D_DRIVER_TYPE_NULL = 3;
+
     }
 }
 #endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryInitializer.cs
@@ -52,8 +52,6 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
 #endif
         }
 
-
-
 #if !NETFX_CORE
         private static IEnumerable<string> GetDrivers()
         {
@@ -117,7 +115,6 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
         private const uint D3D_FEATURE_LEVEL_11_1 = 0xb100;
         private const uint D3D_FEATURE_LEVEL_12_0 = 0xc000;
         private const uint D3D_FEATURE_LEVEL_12_1 = 0xc100;
-
     }
 }
 #endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryModule.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryModule.cs
@@ -1,0 +1,58 @@
+﻿#if NET461 || NETCOREAPP3_0
+using Microsoft.ApplicationInsights.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.ApplicationInsights.WindowsDesktop
+{
+    /// <summary>
+    /// Tracks changes to the WPG Rendering Capability Tier
+    /// </summary>
+    public class GraphicsTelemetryModule : ITelemetryModule, IDisposable
+    {
+        private readonly object _lockObject = new object();
+        private TelemetryClient _telemetryClient;
+        private bool _isInitialized = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphicsTelemetryModule"/> class.
+        /// </summary>
+        public GraphicsTelemetryModule()
+        {
+        }
+
+        /// <inheritdoc cref="ITelemetryModule.Initialize(TelemetryConfiguration)" />
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            // Core SDK creates 1 instance of a module but calls Initialize multiple times
+            if (!this._isInitialized)
+            {
+                lock (_lockObject)
+                {
+                    if (!_isInitialized)
+                    {
+                        _isInitialized = true;
+                        _telemetryClient = new TelemetryClient(configuration);
+                        System.Windows.Media.RenderCapability.TierChanged += RenderCapability_TierChanged;
+                    }
+                }
+            }
+        }
+        private void RenderCapability_TierChanged(object sender, EventArgs e)
+        {
+            _telemetryClient.TrackEvent("WPF Rendering Capability Tier Changed", new Dictionary<string, string> { { "DX Rendering Capability Tier", System.Windows.Media.RenderCapability.Tier.ToString() } });
+        }
+
+        /// <summary>
+        /// Disposing GraphicsTelemetryModule instance.
+        /// </summary>
+        public void Dispose()
+        {
+            System.Windows.Media.RenderCapability.TierChanged -= RenderCapability_TierChanged;
+        }
+    }
+}
+#endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryModule.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/GraphicsTelemetryModule.cs
@@ -41,6 +41,7 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
                 }
             }
         }
+
         private void RenderCapability_TierChanged(object sender, EventArgs e)
         {
             _telemetryClient.TrackEvent("WPF Rendering Capability Tier Changed", new Dictionary<string, string> { { "DX Rendering Capability Tier", System.Windows.Media.RenderCapability.Tier.ToString() } });

--- a/AppInsights.WindowsDesktop/WindowsDesktop/Implementation/WTSSessionHelper.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/Implementation/WTSSessionHelper.cs
@@ -1,0 +1,138 @@
+﻿#if NET461 || NETCOREAPP3_0 || NETFX_CORE
+using System;
+#if !NETFX_CORE
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+#endif
+
+namespace Microsoft.ApplicationInsights.WindowsDesktop
+{
+    internal class WTSSessionHelper
+#if !NETFX_CORE
+        : IDisposable
+#endif
+    {
+        public static bool IsRemoteDesktop
+        {
+            get
+            {
+#if NETFX_CORE
+                return Windows.System.RemoteDesktop.InteractiveSession.IsRemote;
+#else
+                return GetSystemMetrics(SM_REMOTESESSION) != 0;
+#endif
+            }
+        }
+
+#if !NETFX_CORE
+        private IntPtr _hwnd = IntPtr.Zero;
+
+        public WTSSessionHelper(System.Windows.Window window)
+        {
+            if (window == null)
+                return;
+            var wih = new System.Windows.Interop.WindowInteropHelper(window);
+            _hwnd = wih.Handle;
+            var mainWindowHwndSource = System.Windows.PresentationSource.FromVisual(window) as HwndSource;
+            if (mainWindowHwndSource != null)
+                mainWindowHwndSource.AddHook(new HwndSourceHook(WindowHwndMessageFilter));
+            WTSRegisterSessionNotification(_hwnd, NOTIFY_FOR_THIS_SESSION);
+        }
+
+        public static bool IsRemoteControlled => GetSystemMetrics(SM_REMOTECONTROL) != 0;
+
+        public event EventHandler<bool> RemoteDesktopChanged;
+        public event EventHandler<bool> RemoteControlChanged;
+        public event EventHandler<WTSSessionState> SessionStateChanged;
+
+        public void Dispose()
+        {
+            if (_hwnd != IntPtr.Zero)
+            {
+                WTSUnRegisterSessionNotification(_hwnd);
+                _hwnd = IntPtr.Zero;
+            }
+        }
+
+        private IntPtr WindowHwndMessageFilter(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            switch (msg)
+            {
+                case WM_WTSSESSION_CHANGE:
+                    WTSSessionState param = (WTSSessionState)wParam;
+                    switch (param)
+                    {
+                        case WTSSessionState.WTS_SessionConnectedToConsole:
+                            SessionStateChanged?.Invoke(this, param);
+                            RemoteControlChanged?.Invoke(this, true);
+                            break;
+                        case WTSSessionState.WTS_SessionDisconnectedFromConsole:
+                            SessionStateChanged?.Invoke(this, param);
+                            RemoteControlChanged?.Invoke(this, false);
+                            break;
+                        case WTSSessionState.WTS_SessonConnectedToRemoteTerminal:
+                            SessionStateChanged?.Invoke(this, param);
+                            RemoteDesktopChanged?.Invoke(this, true);
+                            break;
+                        case WTSSessionState.WTS_SessionDisconnectedFromRemoteTerminal:
+                            SessionStateChanged?.Invoke(this, param);
+                            RemoteDesktopChanged?.Invoke(this, false);
+                            break;
+                        case WTSSessionState.WTS_UserLoggedOnToSession:
+                        case WTSSessionState.WTS_UserLoggedOffFromSession:
+                        case WTSSessionState.WTS_SessionLocked:
+                        case WTSSessionState.WTS_SessionUnlocked:
+                        case WTSSessionState.WTS_RemoteControlStatusChanged:
+                            SessionStateChanged?.Invoke(this, param);
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            return IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// The Windows Terminal Services Session State
+        /// </summary>
+        public enum WTSSessionState : int
+        {
+            /// <summary>A session was connected to the console terminal.</summary>
+            WTS_SessionConnectedToConsole = 0x1,
+            /// <summary>A session was disconnected from the console terminal.</summary>
+            WTS_SessionDisconnectedFromConsole = 0x2,
+            /// <summary>A session was connected to the remote terminal.</summary>
+            WTS_SessonConnectedToRemoteTerminal = 0x3,
+            /// <summary>A session was disconnected from the remote terminal.</summary>
+            WTS_SessionDisconnectedFromRemoteTerminal = 0x4,
+            /// <summary>A user has logged on to the session.</summary>
+            WTS_UserLoggedOnToSession = 0x5,
+            /// <summary>A user has logged off the session.</summary>
+            WTS_UserLoggedOffFromSession = 0x6,
+            /// <summary>A session has been locked.</summary>
+            WTS_SessionLocked = 0x7,
+            /// <summary>A session has been unlocked.</summary>
+            WTS_SessionUnlocked = 0x8,
+            /// <summary>A session has changed its remote controlled status.</summary>
+            WTS_RemoteControlStatusChanged = 0x9,
+        }
+
+
+        private const int SM_REMOTESESSION = 0x1000;
+        private const int SM_REMOTECONTROL = 0x2001;
+        private const int NOTIFY_FOR_THIS_SESSION = 0;
+        private const int WM_WTSSESSION_CHANGE = 0x2b1;
+
+        [DllImport("user32.dll")]
+        static extern int GetSystemMetrics(int systemMetric);
+
+        [DllImport("wtsapi32.dll", SetLastError = true)]
+        static extern bool WTSRegisterSessionNotification(IntPtr hWnd, [MarshalAs(UnmanagedType.U4)] int dwFlags);
+
+        [DllImport("wtsapi32.dll", SetLastError = true)]
+        static extern bool WTSUnRegisterSessionNotification(IntPtr hWnd);
+#endif
+    }
+}
+#endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryInitializer.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryInitializer.cs
@@ -1,0 +1,29 @@
+﻿#if NET461 || NETCOREAPP3_0 || NETFX_CORE
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.ApplicationInsights.WindowsDesktop
+{
+    /// <summary>
+    /// Tracks the Remote Desktop and Remote Control state of the application
+    /// </summary>
+    public class WTSSessionTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WTSSessionTelemetryInitializer"/> class.
+        /// </summary>
+        public WTSSessionTelemetryInitializer()
+        {
+        }
+
+        /// <inheritdoc cref="ITelemetryInitializer.Initialize(ITelemetry)" />
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.GlobalProperties["Remote Desktop Session"] = WTSSessionHelper.IsRemoteDesktop.ToString();
+#if !NETFX_CORE
+            telemetry.Context.GlobalProperties["Remote Control Session"] = WTSSessionHelper.IsRemoteControlled.ToString();
+#endif
+        }
+    }
+}
+#endif

--- a/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryModule.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryModule.cs
@@ -12,7 +12,7 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
     public class WTSSessionTelemetryModule : ITelemetryModule, IDisposable
     {
         private readonly object _lockObject = new object();
-        private WTSSessionHelper helper;
+        private WTSSessionHelper _helper;
         private TelemetryClient _telemetryClient;
         private bool _isInitialized = false;
 
@@ -51,10 +51,10 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
 
         private void InitializeHelper(Window window)
         {
-            helper = new WTSSessionHelper(window);
-            helper.SessionStateChanged += WTS_SessionStateChanged;
-            helper.RemoteControlChanged += WTS_RemoteControlChanged;
-            helper.RemoteDesktopChanged += WTS_RemoteDesktopChanged;
+            _helper = new WTSSessionHelper(window);
+            _helper.SessionStateChanged += WTS_SessionStateChanged;
+            _helper.RemoteControlChanged += WTS_RemoteControlChanged;
+            _helper.RemoteDesktopChanged += WTS_RemoteDesktopChanged;
         }
 
         /// <inheritdoc cref="ITelemetryModule.Initialize(TelemetryConfiguration)" />
@@ -93,7 +93,7 @@ namespace Microsoft.ApplicationInsights.WindowsDesktop
         /// </summary>
         public void Dispose()
         {
-            helper?.Dispose();
+            _helper?.Dispose();
         }
     }
 }

--- a/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryModule.cs
+++ b/AppInsights.WindowsDesktop/WindowsDesktop/WTSSessionTelemetryModule.cs
@@ -1,0 +1,100 @@
+﻿#if NET461 || NETCOREAPP3_0 
+using Microsoft.ApplicationInsights.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace Microsoft.ApplicationInsights.WindowsDesktop
+{
+    /// <summary>
+    /// Tracks changes to the Windows Terminal Services session, like Remote Desktop, Lock/Unlock etc.
+    /// </summary>
+    public class WTSSessionTelemetryModule : ITelemetryModule, IDisposable
+    {
+        private readonly object _lockObject = new object();
+        private WTSSessionHelper helper;
+        private TelemetryClient _telemetryClient;
+        private bool _isInitialized = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WTSSessionTelemetryModule"/> class.
+        /// </summary>
+        public WTSSessionTelemetryModule() : this(Application.Current.MainWindow)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WTSSessionTelemetryModule"/> class.
+        /// </summary>
+        /// <param name="window">The Window to track WTS state for</param>
+        public WTSSessionTelemetryModule(Window window)
+        {
+            if (window != null)
+            {
+                InitializeHelper(window);
+            }
+            else
+            {
+                Application.Current.Activated += Application_Activated;
+            }
+        }
+
+        private void Application_Activated(object sender, EventArgs e)
+        {
+            var window = Application.Current.MainWindow;
+            if (window != null)
+            {
+                Application.Current.Activated -= Application_Activated;
+                InitializeHelper(window);
+            }
+        }
+
+        private void InitializeHelper(Window window)
+        {
+            helper = new WTSSessionHelper(window);
+            helper.SessionStateChanged += WTS_SessionStateChanged;
+            helper.RemoteControlChanged += WTS_RemoteControlChanged;
+            helper.RemoteDesktopChanged += WTS_RemoteDesktopChanged;
+        }
+
+        /// <inheritdoc cref="ITelemetryModule.Initialize(TelemetryConfiguration)" />
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            if (!this._isInitialized)
+            {
+                lock (_lockObject)
+                {
+                    if (!_isInitialized)
+                    {
+                        _isInitialized = true;
+                        _telemetryClient = new TelemetryClient(configuration);
+                    }
+                }
+            }
+        }
+
+        private void WTS_RemoteDesktopChanged(object sender, bool isRemoteDesktop)
+        {
+            _telemetryClient?.TrackEvent("WTS Remote Desktop Session", new Dictionary<string, string>() { { "Remote Desktop", isRemoteDesktop.ToString() } });
+        }
+
+        private void WTS_RemoteControlChanged(object sender, bool isRemoteControl)
+        {
+            _telemetryClient?.TrackEvent("WTS Remote Control Session", new Dictionary<string, string>() { { "Remote Controlled", isRemoteControl.ToString() } });
+        }
+
+        private void WTS_SessionStateChanged(object sender, WTSSessionHelper.WTSSessionState state)
+        {
+            _telemetryClient?.TrackEvent("WTS Session State Changed", new Dictionary<string, string>() { { "New State", state.ToString() } });
+        }
+
+        /// <summary>
+        /// Disposing WTSSessionTelemetryModule instance.
+        /// </summary>
+        public void Dispose()
+        {
+            helper?.Dispose();
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It adds the following capaiblities (taken from the Windows Server package) to de
 - `UnhandledExceptionTelemetryModule`: reports unhandled exceptions
 - `SessionTelemetryInitializer`: Initializes session id and user id
 - `VersionTelemetryInitializer`: Initializes CLR version and Application Version (from `AssemblyInformationalVersion` attribute of the entrypoint)
+- `WTSSessionTelemetryInitializer`: Reports Remote Desktop and Remote Control states
+- `GraphicsTelemetryInitializer`: Reports various graphics hardware metric like Graphics Card and driver version, supported DirectX Feature Level. Various WPF Rendering settings.
+- `WTSSessionTelemetryModule`: Reports changes to the Windows Terminal Services state, like logging on/off, connect/disconnect remote desktop etc.
+- `GraphicsTelemetryModule`: Reports changes to the graphics capabilities of the system.
 
 
 ## Usage
@@ -29,12 +33,16 @@ Add an `ApplicationInsights.config` file to your main executable project with an
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.DeviceTelemetryInitializer, AppInsights.WindowsDesktop"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.SessionTelemetryInitializer, AppInsights.WindowsDesktop"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.VersionTelemetryInitializer, AppInsights.WindowsDesktop"/>
+    <!--<Add Type="Microsoft.ApplicationInsights.WindowsDesktop.GraphicsTelemetryInitializer, AppInsights.WindowsDesktop"/>-->
+    <!--<Add Type="Microsoft.ApplicationInsights.WindowsDesktop.WTSSessionTelemetryInitializer, AppInsights.WindowsDesktop"/>-->
   </TelemetryInitializers>
   <TelemetryModules>
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.DeveloperModeWithDebuggerAttachedTelemetryModule, AppInsights.WindowsDesktop"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.UnhandledExceptionTelemetryModule, AppInsights.WindowsDesktop"/>
     <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.UnobservedExceptionTelemetryModule, AppInsights.WindowsDesktop" />
     <!--<Add Type="Microsoft.ApplicationInsights.WindowsDesktop.FirstChanceExceptionStatisticsTelemetryModule, AppInsights.WindowsDesktop" />-->
+    <!--<Add Type="Microsoft.ApplicationInsights.WindowsDesktop.WTSSessionTelemetryModule, AppInsights.WindowsDesktop" />-->
+    <!--<Add Type="Microsoft.ApplicationInsights.WindowsDesktop.GraphicsTelemetryModule, AppInsights.WindowsDesktop" />-->
   </TelemetryModules>
   <TelemetryProcessors>
     <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>


### PR DESCRIPTION
These trackers are great for tracking understanding various graphics crashes, as the graphics hardware and changes in state between remote and local all causes various forms of rendering issues and/or crashes.